### PR TITLE
Some filter queries are incompletely converted

### DIFF
--- a/solr/core/src/java/org/apache/solr/query/TFilter.java
+++ b/solr/core/src/java/org/apache/solr/query/TFilter.java
@@ -366,6 +366,8 @@ public class TFilter extends Filter implements DocSetProducer {
         out.add( tq.getTerm().bytes() );
       } else if (sub instanceof BooleanQuery) {
         return getTerms((BooleanQuery) sub, field, out);
+      } else {
+        return null;
       }
     }
 


### PR DESCRIPTION
When FilterQuery has multiple queries which are not in TermQuery,
those conditions of queries will be ignored as searching in that case.
